### PR TITLE
RMET-2089 Payments Plugin - Add access token to backend endpoint call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 04-01-2023
+Android - Add extra parameter for accessToken (https://outsystemsrd.atlassian.net/browse/RMET-2089)
+
 ## 28-12-2022
 Android - update dependency to PaymentsLib-Android (https://outsystemsrd.atlassian.net/browse/RMET-2120)
 

--- a/src/android/com/outsystems/payments/OSPayments.kt
+++ b/src/android/com/outsystems/payments/OSPayments.kt
@@ -100,7 +100,7 @@ class OSPayments : CordovaImplementation() {
         paymentDetails = buildPaymentDetails(args)
 
         if(paymentDetails != null){
-            paymentsController.setDetailsAndTriggerPayment(getActivity(), paymentDetails!!)
+            paymentsController.setDetailsAndTriggerPayment(getActivity(), paymentDetails!!, args.getString(1))
         }
         else{
             sendPluginResult(null, Pair(formatErrorCode(OSPMTError.INVALID_PAYMENT_DETAILS.code), OSPMTError.INVALID_PAYMENT_DETAILS.description))

--- a/src/android/com/outsystems/payments/build.gradle
+++ b/src/android/com/outsystems/payments/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.1.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
-    implementation("com.github.outsystems:ospayments-android:1.0.6@aar")
+    implementation("com.github.outsystems:ospayments-android:1.0.7@aar")
 
     implementation 'com.stripe:stripe-android:20.5.0'
 

--- a/www/OSPayments.js
+++ b/www/OSPayments.js
@@ -8,6 +8,6 @@ exports.checkWalletSetup = function(success, error) {
     exec(success, error, 'OSPayments', 'checkWalletSetup');
 };
 
-exports.setDetails = function(paymentDetails, success, error) {
-    exec(success, error, 'OSPayments', 'setDetails', [paymentDetails]);
+exports.setDetails = function(paymentDetails, accessToken, success, error) {
+    exec(success, error, 'OSPayments', 'setDetails', [paymentDetails, accessToken]);
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- This PR adds a new parameter `accessToken` that we need to pass to the `setDetailsAndTriggerPayment` method of the Payments Lib, so that the accessToken is passed in the request to the backend endpoint to process the payment.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2089

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [x] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS 8 and 9 builds, running the sample app in an Android 12 device.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly

[RMET-2089]: https://outsystemsrd.atlassian.net/browse/RMET-2089?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ