### PR TITLE
RMET-2147 ::: iOS ::: Add Access Token Parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 06-01-2023
+- Feat: [iOS] Add access token to Full Payment Process (https://outsystemsrd.atlassian.net/browse/RMET-2147).
+
 ## 04-01-2023
 Android - Add extra parameter for accessToken (https://outsystemsrd.atlassian.net/browse/RMET-2089)
 

--- a/src/android/com/outsystems/payments/build.gradle
+++ b/src/android/com/outsystems/payments/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.1.0@aar")
     implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
-    implementation("com.github.outsystems:ospayments-android:1.0.7@aar")
+    implementation("com.github.outsystems:ospayments-android:1.0.9@aar")
 
     implementation 'com.stripe:stripe-android:20.5.0'
 

--- a/src/ios/OSPayments.swift
+++ b/src/ios/OSPayments.swift
@@ -28,8 +28,9 @@ class OSPayments: CDVPlugin {
     func setDetails(command: CDVInvokedUrlCommand) {
         self.callbackId = command.callbackId
         
-        guard let detailsText = command.arguments.first as? String else { return }
-        self.plugin?.set(detailsText)
+        guard let detailsText = command.argument(at: 0) as? String else { return }
+        let accessToken = command.argument(at: 1) as? String
+        self.plugin?.set(detailsText, and: accessToken)
     }
 }
 


### PR DESCRIPTION
## Description
- Update iOS library to the latest `development` branch.
- Add a new `accessToken` argument to the `setDetails` method.

We also took the opportunity to update the Android library to the latest version (1.0.9).

## Context
https://outsystemsrd.atlassian.net/browse/RMET-2147

## Type of changes
- [ ] Fix (non-breaking change which fixes an issue)
- [x] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
