### PR TITLE
iOS ::: Fix MABS 9 Build error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+## 09-01-2023
+- Fix: [iOS] Add `post_install` script to podfile in order to fix a XCode 14 code signing issue on Stripe's libraries.
+
 ## 06-01-2023
 - Feat: [iOS] Add access token to Full Payment Process (https://outsystemsrd.atlassian.net/browse/RMET-2147).
 


### PR DESCRIPTION
## Description
Add a `post_install` script to overcome an issue in Xcode 14 when Pods require a provisioning profile for code signing (such as Stripe).

A sample app build was generated on MABS 8 and 9. You can access it through the following:
- MABS 8: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=c9dfd20d9f428bbccb07985c7625d5525747b3c7
- MABS 9: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=45105ac086cef3c9ca6d1e59995b1276a3d5bae2

## Context
Fix an error found during the Payments Test Party.

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
