### PR TITLE
RMET-2855 Payments Plugin - Fix path to look for config file on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
+
+### 03-10-2023
+- Fix: [iOS] Fixes path, removing duplicate string (https://outsystemsrd.atlassian.net/browse/RMET-2855).
+
+### 13-07-2023
 - Feat: Update hook to consider new resources paths (https://outsystemsrd.atlassian.net/browse/RMET-2477)
 
 ### 10-02-2023

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -28,7 +28,7 @@ module.exports = function (context) {
     let platformPath = path.join(projectRoot, 'platforms/ios');
     let resourcesPath = path.join(projectRoot, `platforms/ios/${appName}/Resources/www`);   
     if(!fs.existsSync(resourcesPath)){
-        resourcesPath = path.join(projectRoot, platformPath + "/www");
+        resourcesPath = platformPath + "/www";
     }
 
     //read json config file


### PR DESCRIPTION
 ## Description
<!--- Describe your changes in detail -->

- This PR fixes the `resourcesPath` string, which had a duplicate substring for `source`. With the assignment we had, the path was` sourcesource/platforms...` instead of `"source/platforms..."`.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-2855

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested MABS 10 and 9 builds on O11 and MABS 9 builds on ODC (ring 0):

- O11 MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=402a201a033355467b086e16a1796ee11b0641da
- O11 MABS 9 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=90c2a8c95a46f05b246f83b798b2878439cdbca7
- ODC MABS 9 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=141681467e29e8d8a48688761e9f04c1ca5884e9

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly