### PR TITLE
RMET-2993 Payments Plugin - Fix dependencies and update code accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The changes documented here do not include those from the original repository.
 
 ## [Unreleased]
 
+### 21-12-2023
+- Fix: [Android] Updates dependency to OSCore and OSCordova (https://outsystemsrd.atlassian.net/browse/RMET-2993).
+
 ### 03-10-2023
 - Fix: [iOS] Fixes path, removing duplicate string (https://outsystemsrd.atlassian.net/browse/RMET-2855).
 

--- a/src/android/com/outsystems/payments/OSPayments.kt
+++ b/src/android/com/outsystems/payments/OSPayments.kt
@@ -107,15 +107,17 @@ class OSPayments : CordovaImplementation() {
         }
     }
 
-    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent) {
+    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?) {
         super.onActivityResult(requestCode, resultCode, intent)
-        paymentsController.handleActivityResult(requestCode, resultCode, intent,
-            { paymentResponse ->
-                sendPluginResult(paymentResponse, null)
-            },
-            { error ->
-                sendPluginResult(null, Pair(formatErrorCode(error.code), error.description))
-            })
+        if (intent != null) {
+            paymentsController.handleActivityResult(requestCode, resultCode, intent,
+                { paymentResponse ->
+                    sendPluginResult(paymentResponse, null)
+                },
+                { error ->
+                    sendPluginResult(null, Pair(formatErrorCode(error.code), error.description))
+                })
+        }
     }
 
     override fun onRequestPermissionResult(requestCode: Int,

--- a/src/android/com/outsystems/payments/build.gradle
+++ b/src/android/com/outsystems/payments/build.gradle
@@ -27,8 +27,8 @@ repositories{
 apply plugin: 'kotlin-kapt'
 
 dependencies {
-    implementation("com.github.outsystems:oscore-android:1.1.0@aar")
-    implementation("com.github.outsystems:oscordova-android:1.1.0@aar")
+    implementation("com.github.outsystems:oscore-android:1.2.0@aar")
+    implementation("com.github.outsystems:oscordova-android:2.0.0@aar")
     implementation("com.github.outsystems:ospayments-android:1.1.0@aar")
 
     implementation 'com.stripe:stripe-android:20.5.0'


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

Updates dependencies and update code in `OSPayments.kt` accordingly.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

When using the Payments plugin in an app containing another plugin, if that other plugin was already pointing to more recent versions of oscore-android and oscordova-android, the build would fail because those more recent versions would be used, and the code in OSPayments.kt wasn't compatible with them.

References: https://outsystemsrd.atlassian.net/browse/RMET-2993

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
MABS 10 build using Payments and Social Logins: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=f0a19d17d66cb700817b7765f4a5e8c5923f680b
MABS 9 build using Payments and Social Logins: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=505ef750177c37acfd1b34c1b4e843b658a1bf2a

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
