### PR TITLE
RMET-3390 - Payments Plugin - Use @SerializableName annotation to avoid issues with code obfuscation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 1.2.2
+
+### Fixes
+- Fix: Update dependency to `OSPaymentsLib-Android` that adds `@SerializableName` annotation to avoid issues when using code obfuscation (https://outsystemsrd.atlassian.net/browse/RMET-3387).
+
 ## 1.2.1
 
 ### Fixes

--- a/src/android/com/outsystems/payments/OSPayments.kt
+++ b/src/android/com/outsystems/payments/OSPayments.kt
@@ -11,7 +11,6 @@ import com.outsystems.plugins.payments.model.OSPMTError
 import com.outsystems.plugins.payments.model.PaymentConfigurationInfo
 import com.outsystems.plugins.payments.model.PaymentDetails
 import com.outsystems.plugins.payments.model.Tokenization
-import kotlinx.coroutines.runBlocking
 import org.apache.cordova.CallbackContext
 import org.apache.cordova.CordovaInterface
 import org.apache.cordova.CordovaWebView
@@ -55,22 +54,19 @@ class OSPayments : CordovaImplementation() {
 
     override fun execute(action: String, args: JSONArray, callbackContext: CallbackContext): Boolean {
         this.callbackContext = callbackContext
-        val result = runBlocking {
-            when (action) {
-                "setupConfiguration" -> {
-                    setupConfiguration(args)
-                }
-                "checkWalletSetup" -> {
-                    checkWalletSetup()
-                }
-                "setDetails" -> {
-                    setDetailsAndTriggerPayment(args)
-                }
-                else -> false
+        when (action) {
+            "setupConfiguration" -> {
+                setupConfiguration(args)
             }
-            true
+            "checkWalletSetup" -> {
+                checkWalletSetup()
+            }
+            "setDetails" -> {
+                setDetailsAndTriggerPayment(args)
+            }
+            else -> return false
         }
-        return result
+        return true
     }
 
     private fun setupConfiguration(args: JSONArray) {

--- a/src/android/com/outsystems/payments/build.gradle
+++ b/src/android/com/outsystems/payments/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:ospayments-android:1.1.0@aar")
+    implementation("com.github.outsystems:ospayments-android:1.1.1-dev@aar")
 
     implementation 'com.stripe:stripe-android:20.5.0'
 

--- a/src/android/com/outsystems/payments/build.gradle
+++ b/src/android/com/outsystems/payments/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:ospayments-android:1.1.1@aar")
+    implementation("com.github.outsystems:ospayments-android:1.1.1-dev2@aar")
 
     implementation 'com.stripe:stripe-android:20.5.0'
 

--- a/src/android/com/outsystems/payments/build.gradle
+++ b/src/android/com/outsystems/payments/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:ospayments-android:1.1.1-dev2@aar")
+    implementation("com.github.outsystems:ospayments-android:1.1.1@aar")
 
     implementation 'com.stripe:stripe-android:20.5.0'
 

--- a/src/android/com/outsystems/payments/build.gradle
+++ b/src/android/com/outsystems/payments/build.gradle
@@ -29,7 +29,7 @@ apply plugin: 'kotlin-kapt'
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")
-    implementation("com.github.outsystems:ospayments-android:1.1.1-dev@aar")
+    implementation("com.github.outsystems:ospayments-android:1.1.1@aar")
 
     implementation 'com.stripe:stripe-android:20.5.0'
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- Updates dependency to `OSPaymentsLib-Android `that adds `@SerializableName` annotation to properties of data classes to avoid issues with code obfuscation.
- It also removes the usage of `runBlocking` when calling plugin features, it is unnecessary and we shouldn't be blocking the main thread.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-3390

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

- Tested with MABS 10 build on Android 15 (Pixel 7) and Android 12 (Pixel 3 XL)
- MABS 10 build: https://intranet.outsystems.net/MABS/BuildDetail.aspx?BuildId=2ed3cb9adb89c5f49e2a4d3924df58c242b6b18c

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
