### PR TITLE
RMET-4037 ::: iOS ::: Remove `cordova-plugin-add-swift-support` Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### Chores
+- (ios) Replace `cordova-plugin-add-swift-support` plugin with the `SwiftVersion` preference (https://outsystemsrd.atlassian.net/browse/RMET-4037).
+
 ## 1.2.2
 
 ### Fixes

--- a/plugin.xml
+++ b/plugin.xml
@@ -49,14 +49,11 @@
     <!-- Hooks -->
     <hook type="after_prepare" src="hooks/ios/iOSCopyPreferences.js" />
 
-    <dependency id="cordova-plugin-add-swift-support" url="https://github.com/OutSystems/cordova-plugin-add-swift-support.git#2.0.3-OS1"/>
-
     <config-file parent="/*" target="config.xml">
       <feature name="OSPayments">
         <param name="ios-package" value="OSPayments"/>
       </feature>
-      <preference name="deployment-target" value="13" />
-      <preference name="UseSwiftLanguageVersion" value="5" />
+      <preference name="SwiftVersion" value="5" />
     </config-file>
 
     <config-file target="*-Debug.plist" parent="com.apple.developer.in-app-payments">


### PR DESCRIPTION
## Description
The only thing the plugin needs is the `SwiftVersion`. This is included directly on `plugin.xml`.

### Information Regarding the Failing Check
The `snyk` validation is failing due to an issue detected on Android's `build.gradle` file. As this falls outside the scope of this task, this PR will not be addressing it.

## Context
https://outsystemsrd.atlassian.net/browse/RMET-4037

## Type of changes
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality not to work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Checklist
- [x] Pull request title follows the format `RMET-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
