### PR TITLE
fix(android): Capacitor Release Builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 1.2.5
+
+### Fixes
+- (android) Release builds With Capacitor failing.
+
 ## 1.2.4
 
 ### Features

--- a/hooks/insert_azure_repository.js
+++ b/hooks/insert_azure_repository.js
@@ -1,0 +1,64 @@
+const fs = require('fs');
+const path = require('path');
+
+const platform = process.env.CAPACITOR_PLATFORM_NAME;
+console.log("\tCamera plugin - running hook after update - for " + platform);
+const projectDirPath = process.env.CAPACITOR_ROOT_DIR;
+
+if (platform == 'android') {
+    fixAndroidAzureRepository();
+}
+
+/**
+ * Add the azure repository (where camera native Android library is housed) to project root's build.gradle
+ * Because capacitor plugins are injected as separate gradle modules, this is necessary for release builds lintVital gradle tasks to pass.
+ */
+function fixAndroidAzureRepository() {
+    const gradleFilePath = path.resolve(projectDirPath, 'android/build.gradle');
+    const azureUrl = 'https://pkgs.dev.azure.com/OutSystemsRD/9e79bc5b-69b2-4476-9ca5-d67594972a52/_packaging/PublicArtifactRepository/maven/v1';
+    const mavenBlock = `        maven {
+            url "${azureUrl}"
+        }`;
+
+    let gradleContent = fs.readFileSync(gradleFilePath, 'utf8');
+
+    if (gradleContent.includes(azureUrl)) {
+        console.log('\t[SKIPPED] Azure repository already in root build.gradle.');
+    } else {
+        const allprojectsStart = gradleContent.indexOf('allprojects {');
+        if (allprojectsStart === -1) {
+            console.warn('\t[WARNING] Could not find allprojects { ... } block. Unable to add Azure Repository');
+            return;
+        }
+        const repositoriesStart = gradleContent.indexOf('repositories {', allprojectsStart);
+        if (repositoriesStart === -1) {
+            console.warn('\t[WARNING] Could not find allprojects { repositories { ... } } block. Unable to add Azure Repository');
+            return;
+        }
+        // Track braces to find end of repositories block
+        let braceCount = 0;
+        let i = repositoriesStart + 'repositories {'.length - 1;
+        let endIndex = -1;
+        while (i < gradleContent.length) {
+            if (gradleContent[i] === '{') braceCount++;
+            else if (gradleContent[i] === '}') braceCount--;
+
+            if (braceCount === 0) {
+                endIndex = i;
+                break;
+            }
+            i++;
+        }
+        if (endIndex === -1) {
+            console.warn('\t[WARNING] Could not find allprojects { repositories { ... } } block. Unable to add Azure Repository');
+            return;
+        }
+        const closingBraceLineStartIndex = gradleContent.lastIndexOf('\n', endIndex);
+        // Insert the maven block at the end of the repositories block (before closing brace), because gradle searches repositories by order.
+        // The Azure repo should be the last one since it will only apply for a few dependencies.
+        // Otherwise this could slow down gradle build.
+        const updatedContent = gradleContent.slice(0, closingBraceLineStartIndex) + '\n' + mavenBlock + gradleContent.slice(closingBraceLineStartIndex);
+        fs.writeFileSync(gradleFilePath, updatedContent, 'utf8');
+        console.log('\t[SUCCESS] Added Azure repository maven block to the root build.gradle.');
+    }
+}

--- a/hooks/insert_azure_repository.js
+++ b/hooks/insert_azure_repository.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const path = require('path');
 
 const platform = process.env.CAPACITOR_PLATFORM_NAME;
-console.log("\tCamera plugin - running hook after update - for " + platform);
+console.log("\tPayments plugin - running hook after update - for " + platform);
 const projectDirPath = process.env.CAPACITOR_ROOT_DIR;
 
 if (platform == 'android') {
@@ -10,7 +10,7 @@ if (platform == 'android') {
 }
 
 /**
- * Add the azure repository (where camera native Android library is housed) to project root's build.gradle
+ * Add the azure repository (where payments native Android library is housed) to project root's build.gradle
  * Because capacitor plugins are injected as separate gradle modules, this is necessary for release builds lintVital gradle tasks to pass.
  */
 function fixAndroidAzureRepository() {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.payments",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "OutSystems-owned plugin for mobile payments",
   "keywords": [
     "ecosystem:cordova",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "engines": [],
   "scripts": {
+    "capacitor:update:after": "node hooks/insert_azure_repository.js",
     "capacitor:sync:after": "node hooks/capacitorCopyPreferences.js"
   }
 }

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.payments" version="1.2.4" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.payments" version="1.2.5" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>OSPayments</name>
   <description>OutSystems-owned plugin for mobile payments</description>
   <author>OutSystems Inc</author>


### PR DESCRIPTION
## Description

This fixes release builds with Capacitor / MABS 12, that were failing with:

```
FAILURE: Build failed with an exception.
    * What went wrong: Execution failed for task ':outsystems-capacitor-outsystems-loader:generateReleaseLintModel'.
    > Could not resolve all files for configuration ':outsystems-capacitor-outsystems-loader:releaseRuntimeClasspath'.
```

## Context

References: https://outsystemsrd.atlassian.net/browse/RMET-4257


## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

You can test with this release build for our ODC tenant - https://eng-mobile.outsystems.dev/apps/application?id=120d1742-e8af-4958-b483-59d29a370fa9&tab=mobiledistribution&stageid=82798f0c-48de-4787-b0e1-dd3204ce2e6b&configuration=settings&mobileoption=android

I did a temporary capacitor hook in a separate branch to fix the issue with bad resource files coming from MABS, otherwise the build would fail as well (note that this issue is not specific of this plugin, hence why it's in a temporary branch and not in this PR) - https://github.com/OutSystems/cordova-outsystems-payments/blob/test/RMET-4257/delete-drawable/hooks/insert_azure_repository.js

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [X] Pull request title follows the format `RNMT-XXXX <title>`
- [X] Code follows code style of this project
- [X] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
