### PR TITLE
RMET-4469 ::: fix iOSCopyPreferences hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## Unreleased
+
+### Fixes
+- (iOS) Add fix to `iOSCopyPreferences.js` hook to correctly locate `PaymentsPluginConfiguration.json` on MOCA builds. (https://outsystemsrd.atlassian.net/browse/RMET-4469)
+
 ## 1.2.8
 
 ### Fixes

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -26,7 +26,7 @@ module.exports = function (context) {
     let appName = appNameParser.name();
 
     let platformPath = path.join(projectRoot, 'platforms/ios');
-    let resourcesPath = path.join(projectRoot, `platforms/ios/${appName}/Resources/www`);   
+    let resourcesPath = path.join(projectRoot, `platforms/ios/${appName}/Resources/www`);
     if(!fs.existsSync(resourcesPath)){
         resourcesPath = platformPath + "/www";
     }
@@ -35,7 +35,8 @@ module.exports = function (context) {
     let jsonConfig = "";
     let jsonParsed;
     try {
-        jsonConfig = path.join(resourcesPath, 'json-config/PaymentsPluginConfiguration.json');
+        //jsonConfig = path.join(resourcesPath, 'json-config/PaymentsPluginConfiguration.json');
+        jsonConfig = getConfigPath(appName, platformPath, resourcesPath)
         let jsonConfigFile = fs.readFileSync(jsonConfig, 'utf8');
         jsonParsed = JSON.parse(jsonConfigFile);
     } catch {
@@ -154,3 +155,11 @@ module.exports = function (context) {
 
     fs.writeFileSync(releaseEntitlementsPath, plist.build(releaseEntitlements, { indent: '\t' }));
 };
+
+function getConfigPath(appName, platformPath, resourcesPath) {
+    let newPath = path.join(platformPath, appName, "json-config/PaymentsPluginConfiguration.json");
+    if (fs.existsSync(newPath)) {
+        return newPath;
+    }
+    return path.join(resourcesPath, "json-config/PaymentsPluginConfiguration.json");
+}

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -25,11 +25,19 @@ module.exports = function (context) {
     let appNameParser = new ConfigParser(appNamePath);
     let appName = appNameParser.name();
 
-    let platformPath = path.join(projectRoot, 'platforms/ios');
-    let resourcesPath = path.join(projectRoot, `platforms/ios/${appName}/Resources/www`);
+    let platformPath = path.join(projectRoot, "platforms/ios");
+    /* let resourcesPath = path.join(projectRoot, `platforms/ios/${appName}/Resources/www`);
     if(!fs.existsSync(resourcesPath)){
         console.log("entered first if");
         resourcesPath = platformPath + "/www";
+    }*/
+
+    let resourcesPath = path.join(platformPath, appName, "Resources");
+    if (fs.existsSync(path.join(resourcesPath, "json-config"))) {
+      console.log("MOCA BUILD 11.2/12");
+    }else {
+      console.log("MABS 11.1");
+      resourcesPath = path.join(platformPath, appName, "Resources/www");
     }
 
     //read json config file
@@ -38,6 +46,7 @@ module.exports = function (context) {
     try {
         //jsonConfig = path.join(resourcesPath, 'json-config/PaymentsPluginConfiguration.json');
         jsonConfig = getConfigPath(appName, platformPath, resourcesPath)
+        console.log("Returned path: ", jsonConfig);
         let jsonConfigFile = fs.readFileSync(jsonConfig, 'utf8');
         jsonParsed = JSON.parse(jsonConfigFile);
     } catch {
@@ -159,7 +168,7 @@ module.exports = function (context) {
 
 function getConfigPath(appName, platformPath, resourcesPath) {
     let newPath = path.join(platformPath, appName, "json-config/PaymentsPluginConfiguration.json");
-    console.log("before if(newPath)");
+    console.log("before if newpath: " + newPath);
     if (fs.existsSync(newPath)) {
         console.log("entered if");
         return newPath;

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -29,10 +29,7 @@ module.exports = function (context) {
     let resourcesPath = path.join(platformPath, appName, "Resources");
 
     if (!fs.existsSync(path.join(resourcesPath, "json-config"))) {
-      console.log("====> MABS 11.1");
       resourcesPath = path.join(platformPath, appName, "Resources/www");
-    } else {
-      console.log("====> MOCA BUILD 11.2/12");
     }
 
     //read json config file
@@ -40,7 +37,6 @@ module.exports = function (context) {
     let jsonParsed;
     try {
         jsonConfig = path.join(resourcesPath, 'json-config/PaymentsPluginConfiguration.json');
-        console.log("====> Returned path: ", jsonConfig);
         let jsonConfigFile = fs.readFileSync(jsonConfig, 'utf8');
         jsonParsed = JSON.parse(jsonConfigFile);
     } catch {

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -26,27 +26,21 @@ module.exports = function (context) {
     let appName = appNameParser.name();
 
     let platformPath = path.join(projectRoot, "platforms/ios");
-    /* let resourcesPath = path.join(projectRoot, `platforms/ios/${appName}/Resources/www`);
-    if(!fs.existsSync(resourcesPath)){
-        console.log("entered first if");
-        resourcesPath = platformPath + "/www";
-    }*/
-
     let resourcesPath = path.join(platformPath, appName, "Resources");
-    if (fs.existsSync(path.join(resourcesPath, "json-config"))) {
-      console.log("MOCA BUILD 11.2/12");
-    }else {
-      console.log("MABS 11.1");
+
+    if (!fs.existsSync(path.join(resourcesPath, "json-config"))) {
+      console.log("====> MABS 11.1");
       resourcesPath = path.join(platformPath, appName, "Resources/www");
+    } else {
+      console.log("====> MOCA BUILD 11.2/12");
     }
 
     //read json config file
     let jsonConfig = "";
     let jsonParsed;
     try {
-        //jsonConfig = path.join(resourcesPath, 'json-config/PaymentsPluginConfiguration.json');
-        jsonConfig = getConfigPath(appName, platformPath, resourcesPath)
-        console.log("Returned path: ", jsonConfig);
+        jsonConfig = path.join(resourcesPath, 'json-config/PaymentsPluginConfiguration.json');
+        console.log("====> Returned path: ", jsonConfig);
         let jsonConfigFile = fs.readFileSync(jsonConfig, 'utf8');
         jsonParsed = JSON.parse(jsonConfigFile);
     } catch {
@@ -165,14 +159,3 @@ module.exports = function (context) {
 
     fs.writeFileSync(releaseEntitlementsPath, plist.build(releaseEntitlements, { indent: '\t' }));
 };
-
-function getConfigPath(appName, platformPath, resourcesPath) {
-    let newPath = path.join(platformPath, appName, "json-config/PaymentsPluginConfiguration.json");
-    console.log("before if newpath: " + newPath);
-    if (fs.existsSync(newPath)) {
-        console.log("entered if");
-        return newPath;
-    }
-    console.log("about to return getConfigPath");
-    return path.join(resourcesPath, "json-config/PaymentsPluginConfiguration.json");
-}

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -28,6 +28,7 @@ module.exports = function (context) {
     let platformPath = path.join(projectRoot, 'platforms/ios');
     let resourcesPath = path.join(projectRoot, `platforms/ios/${appName}/Resources/www`);
     if(!fs.existsSync(resourcesPath)){
+        console.log("entered first if");
         resourcesPath = platformPath + "/www";
     }
 
@@ -158,8 +159,11 @@ module.exports = function (context) {
 
 function getConfigPath(appName, platformPath, resourcesPath) {
     let newPath = path.join(platformPath, appName, "json-config/PaymentsPluginConfiguration.json");
+    console.log("before if(newPath)");
     if (fs.existsSync(newPath)) {
+        console.log("entered if");
         return newPath;
     }
+    console.log("about to return getConfigPath");
     return path.join(resourcesPath, "json-config/PaymentsPluginConfiguration.json");
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add fix to iOSCopyPreferences.js hook to correctly locate PaymentsPluginConfiguration.json on MOCA builds.

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->
References: https://outsystemsrd.atlassian.net/browse/RMET-4469

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [] Android
- [x] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->
Tested on ODC with MABS 11.1, 11.2, and 12 to ensure everything works properly.  
You can use our Payments sample app to check this fix.


## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
