### PR TITLE
fix(android): remove unnecessary `kotlin-kapt`, fixing Capacitor builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 1.2.10
+
+### Fixes
+- (android) Removes the `kotlin-kapt` plugin that was being added, fixing builds for Capacitor apps (https://outsystemsrd.atlassian.net/browse/RMET-4515)
+
 ## 1.2.9
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.payments",
-  "version": "1.2.9",
+  "version": "1.2.10",
   "description": "OutSystems-owned plugin for mobile payments",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.payments" version="1.2.9" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.payments" version="1.2.10" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>OSPayments</name>
   <description>OutSystems-owned plugin for mobile payments</description>
   <author>OutSystems Inc</author>

--- a/src/android/com/outsystems/payments/build.gradle
+++ b/src/android/com/outsystems/payments/build.gradle
@@ -23,9 +23,6 @@ repositories{
     }
 }
 
-
-apply plugin: 'kotlin-kapt'
-
 dependencies {
     implementation("com.github.outsystems:oscore-android:1.2.0@aar")
     implementation("com.github.outsystems:oscordova-android:2.0.1@aar")


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

- removes the `kotlin-kapt` plugin that was being added, fixing builds for Capacitor apps once the changes in [this PR](https://github.com/OutSystems/capacitor-mobile-nativeshell/pull/152) are merged

## Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Place the link to the issue here -->

References: https://outsystemsrd.atlassian.net/browse/RMET-4515

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [x] Android
- [ ] iOS
- [ ] JavaScript

## Tests
<!--- Describe how you tested your changes in detail -->
<!--- Include details of your test environment if relevant -->

Tested by generating MABS 12 build of the Payments Sample App in ODC and removing the entry that comes from the Android Capacitor template, to simulate what a MABS 12 build will be like once this is removed from the template.

Also tested this with MABS 11 build.

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
	- [ ] Documentation has been updated accordingly
