### PR TITLE
fix: Correctly detect ios App name in Cordova hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## [Unreleased]
+
+### Fixes
+
+- (iOS) Correct hook to work on Cordova iOS 8 (https://outsystemsrd.atlassian.net/browse/RMET-5120)
+
 ## 1.2.14
 
 ### Chores

--- a/hooks/ios/iOSCopyPreferences.js
+++ b/hooks/ios/iOSCopyPreferences.js
@@ -24,8 +24,12 @@ module.exports = function (context) {
     let appNamePath = path.join(projectRoot, 'config.xml');
     let appNameParser = new ConfigParser(appNamePath);
     let appName = appNameParser.name();
-
     let platformPath = path.join(projectRoot, "platforms/ios");
+    // Cordova iOS 8 uses 'App' as the fixed project folder;
+    //  earlier versions used the app name
+    if (fs.existsSync(path.join(platformPath, 'App'))) {
+        appName = 'App';
+    }
 
     // first we look for the platforms/ios/<AppName>/Resources directory
     let resourcesPath = fs.existsSync(platformPath, appName, "Resources/json-config")


### PR DESCRIPTION
## Description

This PR fixes the Cordova hook for iOS that writes payment configurations into Info.plist file. Cordova iOS 7 and below used the app name for the plist file name, but now with Cordova iOS 8 they are under a generic `App` (which is what the PR fixes).

Because this involves support for Cordova iOS 8, which OutSystems does not use yet, not looking into releasing this at this time since there's no benefit; to be bundled with any other change or we can release whenever cordova iOS 8 in MABS comes and we can test with. If you think we should release now feel free to comment with your reasoning.

## Context

https://outsystemsrd.atlassian.net/browse/RMET-5120

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests

Tested with Cordova iOS 8, a simple payment is working - https://github.com/ionic-team/cordova-plugins-ios-spm-test-apps/tree/main/payments_cordova_ios8

Also checked if current MABS versions with Cordova are still working, and they are. Tested on O11:

- [MABS 11.2 build, requires SSO to access](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=58f81a17899bd38abf944b8ca45ebc78abefb8e9&stg=dev)
- [MABS 12.0 build, requires SSO to access](https://intranet.outsystems.net/MABS_Lite/BuildDetail?id=ce3288df92c3f437765398c8fb1034caff26bb19&stg=dev)

No point in testing Capacitor builds for this change because this a Cordova hook change, does not run for Capacitor.