### PR TITLE
chore: Prepare 1.2.15 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
-## [Unreleased]
+## 1.2.15
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.payments",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "description": "OutSystems-owned plugin for mobile payments",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.payments" version="1.2.14" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.payments" version="1.2.15" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>OSPayments</name>
   <description>OutSystems-owned plugin for mobile payments</description>
   <author>OutSystems Inc</author>


### PR DESCRIPTION
# This repo requires 2 approvals to merge the PR

I had not tied https://github.com/OutSystems/cordova-outsystems-payments/pull/73 to the next version because I didn't think it was being released any time soon.

However, per https://outsystemsrd.atlassian.net/browse/RMET-5166 we may be releasing this soon, so marking this as version 1.2.15; I can't push directly to main in this repo so opening a PR