### PR TITLE
ci: allow triggering release flow manually

### DIFF
--- a/.github/workflows/release_on_main.yml
+++ b/.github/workflows/release_on_main.yml
@@ -3,6 +3,7 @@ name: Release on main
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
At first was only allowing triggering release on push to main, but we should be able to do it manually too, in case something goes wrong.