### PR TITLE
chore: update dependency to OSPaymentsLib-Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 The changes documented here do not include those from the original repository.
 
+## 1.2.16
+
+### Chores
+
+- chore: update dependency to OSPaymentsLib-Android (#77)
+
 ## 1.2.15
 
 ### Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.outsystems.payments",
-  "version": "1.2.15",
+  "version": "1.2.16",
   "description": "OutSystems-owned plugin for mobile payments",
   "keywords": [
     "ecosystem:cordova",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<plugin id="com.outsystems.payments" version="1.2.15" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
+<plugin id="com.outsystems.payments" version="1.2.16" xmlns="http://apache.org/cordova/ns/plugins/1.0" xmlns:android="http://schemas.android.com/apk/res/android">
   <name>OSPayments</name>
   <description>OutSystems-owned plugin for mobile payments</description>
   <author>OutSystems Inc</author>

--- a/src/android/com/outsystems/payments/build.gradle
+++ b/src/android/com/outsystems/payments/build.gradle
@@ -24,7 +24,7 @@ repositories{
 }
 
 dependencies {
-    implementation("com.github.outsystems:ospayments-android:1.1.3@aar")
+    implementation("com.github.outsystems:ospayments-android:1.1.4@aar")
 
     implementation 'com.stripe:stripe-android:20.5.0'
 


### PR DESCRIPTION
## Summary
- Bumps the `ospayments-android` dependency to `1.1.4`, which removes `usesCleartextTraffic` from the library's manifest ahead of Android 17's deprecation of that attribute.

Ref: https://outsystemsrd.atlassian.net/browse/RMET-5242

**Draft**: blocked until [OSPaymentsLib-Android#29](https://github.com/OutSystems/OSPaymentsLib-Android/pull/29) is merged and version `1.1.4` is published to the artifact feed. No plugin release is needed for this change.

## Test plan
- [ ] Once 1.1.4 is published, confirm the plugin still builds and resolves the dependency correctly